### PR TITLE
fix one line sheet read bug

### DIFF
--- a/lib/spreadsheet-reader.js
+++ b/lib/spreadsheet-reader.js
@@ -56,6 +56,7 @@ var SpreadsheetReader = function (path, options) {
                 break;
             case 's':
                 // if we are changing sheets, flush rows immediately
+                rowIndex = -1;
                 sheet && flushRows();
                 sheet = {
                     index: value.index,


### PR DESCRIPTION
- BUG: if only one line in a sheet, then can not read first line in next sheet.
- reset rowIndex on message[0] === 's'
